### PR TITLE
fix: incorrect error message

### DIFF
--- a/streamsight/evaluators/util.py
+++ b/streamsight/evaluators/util.py
@@ -92,4 +92,5 @@ class AlgorithmStatusWarning(UserWarning):
             super().__init__(f"Algorithm:{algo_id} current status is {status}. Algorithm should request for unlabeled data first.")
         elif phase == "complete":
             super().__init__(f"Algorithm:{algo_id} current status is {status}. Algorithm has completed stream evaluation. No more data release available.")
-        super().__init__(f"Algorithm:{algo_id} current status is {status}.")
+        else:
+            super().__init__(f"Algorithm:{algo_id} current status is {status}.")


### PR DESCRIPTION
Closes #88 

Current:
<img width="1051" alt="Screenshot 2024-09-06 at 12 07 34 PM" src="https://github.com/user-attachments/assets/3faec801-0f9c-4d2e-9345-d410da5f707e">

The default final super() is always being called because  it is outside of the conditional blocks. Therefore, it overrides any previous call to [super().__init__]